### PR TITLE
add weights clipping

### DIFF
--- a/merge_models.py
+++ b/merge_models.py
@@ -32,6 +32,7 @@ def compute_weights(weights, base):
         case_sensitive=False,
     ),
 )
+@click.option("-wc", "--weights_clip", "weights_clip", type=float, flag_value=0., default=None)
 @click.option("-p", "--precision", "precision", type=int, default=16)
 @click.option("-o", "--output_path", "output_path", type=str, default="model_out")
 @click.option(
@@ -49,6 +50,7 @@ def main(
     model_b,
     model_c,
     merge_mode,
+    weights_clip,
     precision,
     output_path,
     output_format,
@@ -69,7 +71,7 @@ def main(
         bases["beta"] = base_beta
 
     merged = merge_models(
-        models, weights, bases, merge_mode, precision
+        models, weights, bases, merge_mode, precision, weights_clip
     )
     save_model(merged, output_path, output_format)
 

--- a/sd_meh/merge.py
+++ b/sd_meh/merge.py
@@ -160,6 +160,7 @@ def merge_key(
 
 
 def clip(t, threshold, soft_amount):
+    soft_amount /= 10
     if soft_amount <= EPSILON:
         return torch.minimum(torch.maximum(t, -threshold), threshold)
 


### PR DESCRIPTION
Add the `-wc` flag to clip the weights using `max(|A|, |B|)` as the threshold. Examples:
- `merge_models.py` : do not clip
- `merge_models.py -wc` : hard clip
- `merge_models.py -wc 0.0` : hard clip
- `merge_models.py -wc 0.04` : soft clip

Desmos to get a feel for the soft clipping parmeters: https://www.desmos.com/calculator/brc7rgpvkn