### PR TITLE
feat: Better alpha for trans dist

### DIFF
--- a/sd_meh/merge_methods.py
+++ b/sd_meh/merge_methods.py
@@ -63,7 +63,6 @@ def triple_sum(
     return (1 - alpha - beta) * a + alpha * b + beta * c
 
 
-<<<<<<< HEAD
 def euclidean_add_difference(
     a: Tensor, b: Tensor, c: Tensor, alpha: float, **kwargs
 ) -> Tensor:

--- a/sd_meh/merge_methods.py
+++ b/sd_meh/merge_methods.py
@@ -92,8 +92,8 @@ def multiply_difference(
 
 
 def transmogrify_distribution(a: Tensor, b: Tensor, alpha: float, **kwargs) -> Tensor:
-    a_dist, a_indices = torch.sort(torch.flatten(a.cuda()))
-    b_indices = torch.argsort(torch.flatten(b.cuda()), stable=True)
+    a_dist, a_indices = torch.sort(torch.flatten(a))
+    b_indices = torch.argsort(torch.flatten(b), stable=True)
 
     index_begin = int(alpha * torch.numel(a) / 2)
     index_end = torch.numel(a) - index_begin
@@ -104,7 +104,7 @@ def transmogrify_distribution(a: Tensor, b: Tensor, alpha: float, **kwargs) -> T
     ])
     a_redist = torch.gather(a_dist, 0, redist_indices)
     a_trans = a_redist.reshape(a.shape)
-    return a_trans.cpu()
+    return a_trans
 
 
 def similarity_add_difference(


### PR DESCRIPTION
It seems I didn't test the code properly last time because it certainly works.

Alpha is used to determine the proportion of weights to rearrange. The current algo will duplicate some of the weights 0 to 1 times by swapping only one of two related values. Alpha corresponds to the red section in the weights distribution:

![image](https://github.com/s1dlx/meh/assets/32277961/6f7661d8-a781-4b4b-a3fc-32ea06febef6)
