### PR TITLE
feat: Model substraction before merge

### DIFF
--- a/merge_models.py
+++ b/merge_models.py
@@ -11,6 +11,7 @@ from utils import MERGE_METHODS, weights_and_bases
 @click.option("-a", "--model_a", "model_a", type=str)
 @click.option("-b", "--model_b", "model_b", type=str)
 @click.option("-c", "--model_c", "model_c", default=None, type=str)
+@click.option("-d_sub", "--model_d_sub", "model_d_sub", default=None, type=str)
 @click.option(
     "-m",
     "--merging_method",
@@ -115,6 +116,7 @@ def main(
     model_a,
     model_b,
     model_c,
+    model_d_sub,
     merge_mode,
     weights_clip,
     precision,
@@ -141,10 +143,6 @@ def main(
     if logging_level:
         logging.basicConfig(format="%(levelname)s: %(message)s", level=logging_level)
 
-    models = {"model_a": model_a, "model_b": model_b}
-    if model_c:
-        models["model_c"] = model_c
-
     weights, bases = weights_and_bases(
         merge_mode,
         weights_alpha,
@@ -160,7 +158,10 @@ def main(
     )
 
     merged = merge_models(
-        models,
+        model_a,
+        model_b,
+        model_c,
+        model_d_sub,
         weights,
         bases,
         merge_mode,

--- a/merge_models.py
+++ b/merge_models.py
@@ -143,6 +143,12 @@ def main(
     if logging_level:
         logging.basicConfig(format="%(levelname)s: %(message)s", level=logging_level)
 
+    models = {"model_a": model_a, "model_b": model_b}
+    if(model_c):
+        models["model_c"] = model_c
+    if(model_d_sub):
+        models["model_d"] = model_d_sub
+
     weights, bases = weights_and_bases(
         merge_mode,
         weights_alpha,
@@ -158,10 +164,7 @@ def main(
     )
 
     merged = merge_models(
-        model_a,
-        model_b,
-        model_c,
-        model_d_sub,
+        models,
         weights,
         bases,
         merge_mode,

--- a/merge_models.py
+++ b/merge_models.py
@@ -144,9 +144,9 @@ def main(
         logging.basicConfig(format="%(levelname)s: %(message)s", level=logging_level)
 
     models = {"model_a": model_a, "model_b": model_b}
-    if(model_c):
+    if model_c:
         models["model_c"] = model_c
-    if(model_d_sub):
+    if model_d_sub:
         models["model_d"] = model_d_sub
 
     weights, bases = weights_and_bases(

--- a/sd_meh/merge.py
+++ b/sd_meh/merge.py
@@ -198,7 +198,11 @@ def merge_models(
     if re_basin:
         if "model_c" in models:
             merged = rebasin_merge(
-                {"model_a": thetas["model_a"], "model_b": thetas["model_b"], "model_c": thetas["model_c"]},
+                {
+                    "model_a": thetas["model_a"],
+                    "model_b": thetas["model_b"],
+                    "model_c": thetas["model_c"],
+                },
                 weights,
                 bases,
                 merge_mode,
@@ -211,7 +215,14 @@ def merge_models(
             )
             # clip only after the last re-basin iteration
             if weights_clip:
-                merged = clip_weights({"model_a": thetas["model_a"], "model_b": thetas["model_b"], "model_c": thetas["model_c"]}, merged)
+                merged = clip_weights(
+                    {
+                        "model_a": thetas["model_a"],
+                        "model_b": thetas["model_b"],
+                        "model_c": thetas["model_c"],
+                    },
+                    merged,
+                )
         else:
             merged = rebasin_merge(
                 {"model_a": thetas["model_a"], "model_b": thetas["model_b"]},
@@ -227,11 +238,17 @@ def merge_models(
             )
             # clip only after the last re-basin iteration
             if weights_clip:
-                merged = clip_weights({"model_a": thetas["model_a"], "model_b": thetas["model_b"]}, merged)
+                merged = clip_weights(
+                    {"model_a": thetas["model_a"], "model_b": thetas["model_b"]}, merged
+                )
     else:
         if "model_c" in models:
             merged = simple_merge(
-                {"model_a": thetas["model_a"], "model_b": thetas["model_b"], "model_c": thetas["model_c"]},
+                {
+                    "model_a": thetas["model_a"],
+                    "model_b": thetas["model_b"],
+                    "model_c": thetas["model_c"],
+                },
                 weights,
                 bases,
                 merge_mode,
@@ -253,7 +270,7 @@ def merge_models(
                 work_device=work_device,
                 threads=threads,
             )
-        
+
     if "model_d" in models:
         logging.info(f"add back into d")
         merged = simple_merge(
@@ -269,7 +286,6 @@ def merge_models(
         )
 
     return un_prune_model(merged, thetas, models, device, prune, precision)
-
 
 
 def un_prune_model(

--- a/sd_meh/merge.py
+++ b/sd_meh/merge.py
@@ -129,10 +129,7 @@ def load_thetas(
 
 
 def merge_models(
-    model_a: str,
-    model_b: str,
-    model_c: str,
-    model_d_sub: str,
+    models: Dict[str, os.PathLike | str],
     weights: Dict,
     bases: Dict,
     merge_mode: str,
@@ -145,9 +142,9 @@ def merge_models(
     prune: bool = False,
     threads: int = 1,
 ) -> Dict:
-    if model_d_sub:
-        models = {"model_a": model_a, "model_b": model_d_sub}
-        theta_temp = load_thetas(models, prune, device, precision)
+    if "model_d" in models:
+        models_temp = {"model_a": models["model_a"], "model_b": models["model_d"]}
+        theta_temp = load_thetas(models_temp, prune, device, precision)
         a_sub = simple_merge(
             theta_temp,
             weights,
@@ -160,8 +157,8 @@ def merge_models(
             threads=threads,
         )
 
-        models = {"model_a": model_b, "model_b": model_d_sub}
-        theta_temp = load_thetas(models, prune, device, precision)
+        models_temp = {"model_a": models["model_b"], "model_b": models["model_d"]}
+        theta_temp = load_thetas(models_temp, prune, device, precision)
         b_sub = simple_merge(
             theta_temp,
             weights,
@@ -176,9 +173,9 @@ def merge_models(
 
         thetas = {"model_a": a_sub, "model_b": b_sub}
 
-        if model_c:
-            models = {"model_a": model_c, "model_b": model_d_sub}
-            theta_temp = load_thetas(models, prune, device, precision)
+        if "model_c" in models:
+            models_temp = {"model_a": models["model_c"], "model_b": models["model_d"]}
+            theta_temp = load_thetas(models_temp, prune, device, precision)
             c_sub = simple_merge(
                 theta_temp,
                 weights,
@@ -193,9 +190,9 @@ def merge_models(
             
             thetas["model_c"] = c_sub
     else:
-        models = {"model_a": model_a, "model_b": model_b}
-        if model_c:
-            models["model_c"] = model_c
+        models_temp = {"model_a": models["model_a"], "model_b": models["model_b"]}
+        if "model_c" in models:
+            models_temp["model_c"] = models["model_c"]
         thetas = load_thetas(models, prune, device, precision)
 
     logging.info(f"start merging with {merge_mode} method")
@@ -228,8 +225,8 @@ def merge_models(
             threads=threads,
         )
 
-    if model_d_sub:
-        theta_temp = load_thetas({"model_a": model_d_sub}, prune, device, precision)
+    if "model_d" in models:
+        theta_temp = load_thetas({"model_a": models["model_d"]}, prune, device, precision)
         theta_temp["model_b"] = merged
         merged = simple_merge(
             theta_temp,

--- a/sd_meh/merge_methods.py
+++ b/sd_meh/merge_methods.py
@@ -18,7 +18,7 @@ __all__ = [
     "distribution_crossover",
     "ties_add_difference",
     "pure_difference",
-    "pure_addition"
+    "pure_addition",
 ]
 
 
@@ -212,8 +212,10 @@ def filter_top_k(a: Tensor, k: float):
     top_k_filter = (torch.abs(a) >= k_value).float()
     return a * top_k_filter
 
+
 def pure_difference(a: Tensor, b: Tensor, alpha: float, **kwargs) -> Tensor:
     return a - b
+
 
 def pure_addition(a: Tensor, b: Tensor, alpha: float, **kwargs) -> Tensor:
     return a + b

--- a/sd_meh/merge_methods.py
+++ b/sd_meh/merge_methods.py
@@ -17,6 +17,8 @@ __all__ = [
     "similarity_add_difference",
     "distribution_crossover",
     "ties_add_difference",
+    "pure_difference",
+    "pure_addition"
 ]
 
 
@@ -209,3 +211,9 @@ def filter_top_k(a: Tensor, k: float):
     k_value, _ = torch.kthvalue(torch.abs(a.flatten()).float(), k)
     top_k_filter = (torch.abs(a) >= k_value).float()
     return a * top_k_filter
+
+def pure_difference(a: Tensor, b: Tensor, alpha: float, **kwargs) -> Tensor:
+    return a - b
+
+def pure_addition(a: Tensor, b: Tensor, alpha: float, **kwargs) -> Tensor:
+    return a + b


### PR DESCRIPTION
Automatically substracts a third/fourth model D from A,B and if it exists C before merging them. Adds the merge back into D after automatically.

-Needs code clean-up. 
-Also currently does 4/5 merges instead of 1, though the extra ones seem fast.
-Doesn't do rebasin on the extra merges and I have no idea if it would help.
-Changes the function header for merge_models and this will break repositories that currently use this library.
-Because of current status it's WIP!