### PR TITLE
fix: weights clip rebasin with the proper model A

### DIFF
--- a/sd_meh/merge.py
+++ b/sd_meh/merge.py
@@ -152,15 +152,12 @@ def merge_models(
             bases,
             merge_mode,
             precision=precision,
-            weights_clip=False,
+            weights_clip=weights_clip,
             iterations=iterations,
             device=device,
             work_device=work_device,
             threads=threads,
         )
-        # clip only after the last re-basin iteration
-        if weights_clip:
-            merged = clip_weights(thetas, merged)
     else:
         merged = simple_merge(
             thetas,
@@ -298,7 +295,7 @@ def rebasin_merge(
             new_bases,
             merge_mode,
             precision,
-            weights_clip,
+            False,
             device,
             work_device,
             threads,
@@ -344,7 +341,12 @@ def rebasin_merge(
 
         log_vram("model a updated")
 
-    return thetas["model_a"]
+    merged = thetas["model_a"]
+    thetas["model_a"] = model_a
+    if weights_clip:
+        merged = clip_weights(thetas, merged)
+
+    return merged
 
 
 def simple_merge_key(progress, key, thetas, *args, **kwargs):

--- a/sd_meh/merge.py
+++ b/sd_meh/merge.py
@@ -341,13 +341,12 @@ def rebasin_merge(
 
         log_vram("model a updated")
 
-    merged = thetas["model_a"]
-    clip_thetas = thetas.copy()
-    clip_thetas["model_a"] = model_a
     if weights_clip:
-        merged = clip_weights(clip_thetas, merged)
+        clip_thetas = thetas.copy()
+        clip_thetas["model_a"] = model_a
+        thetas["model_a"] = clip_weights(clip_thetas, thetas["model_a"])
 
-    return merged
+    return thetas["model_a"]
 
 
 def simple_merge_key(progress, key, thetas, *args, **kwargs):

--- a/sd_meh/merge.py
+++ b/sd_meh/merge.py
@@ -342,9 +342,10 @@ def rebasin_merge(
         log_vram("model a updated")
 
     merged = thetas["model_a"]
-    thetas["model_a"] = model_a
+    clip_thetas = thetas.copy()
+    clip_thetas["model_a"] = model_a
     if weights_clip:
-        merged = clip_weights(thetas, merged)
+        merged = clip_weights(clip_thetas, merged)
 
     return merged
 


### PR DESCRIPTION
As model A is modified in place during rebasin merging, the clipping weights procedure needs to receive the proper model A. This fixes that.