### PR TITLE
fix: Weights clip for rebasin

### DIFF
--- a/sd_meh/merge.py
+++ b/sd_meh/merge.py
@@ -152,15 +152,12 @@ def merge_models(
             bases,
             merge_mode,
             precision=precision,
-            weights_clip=False,
+            weights_clip=weights_clip,
             iterations=iterations,
             device=device,
             work_device=work_device,
             threads=threads,
         )
-        # clip only after the last re-basin iteration
-        if weights_clip:
-            merged = clip_weights(thetas, merged)
     else:
         merged = simple_merge(
             thetas,
@@ -298,7 +295,7 @@ def rebasin_merge(
             new_bases,
             merge_mode,
             precision,
-            weights_clip,
+            False,
             device,
             work_device,
             threads,
@@ -343,6 +340,11 @@ def rebasin_merge(
         )
 
         log_vram("model a updated")
+
+    if weights_clip:
+        clip_thetas = thetas.copy()
+        clip_thetas["model_a"] = model_a
+        thetas["model_a"] = clip_weights(thetas, thetas["model_a"])
 
     return thetas["model_a"]
 


### PR DESCRIPTION
As model A is modified in place during rebasin merging, the clipping weights procedure needs to receive the proper model A. This fixes that.