### PR TITLE
fix: Weights clipping range is wrong

### DIFF
--- a/sd_meh/merge.py
+++ b/sd_meh/merge.py
@@ -430,10 +430,8 @@ def clip_weights(thetas, merged):
 def clip_weights_key(thetas, merged_weights, key):
     t0 = thetas["model_a"][key]
     t1 = thetas["model_b"][key]
-    stacked_thetas = torch.stack([torch.flatten(t0), torch.flatten(t1)])
-    argmin = torch.argmin(stacked_thetas, dim=0).reshape_as(t0)
-    maximums = argmin * t0 + (1 - argmin) * t1
-    minimums = (1 - argmin) * t0 + argmin * t1
+    maximums = torch.maximum(t0, t1)
+    minimums = torch.minimum(t0, t1)
     return torch.minimum(torch.maximum(merged_weights, minimums), maximums)
 
 


### PR DESCRIPTION
Instead of $[-max(|a|, |b|), max(|a|, |b|)]$, use $[min(a, b), max(a, b)]$ as the safe value range.

Here's an example of merge using add difference with $\alpha = 1.0$, A = ghostmix_v12, B = lyriel_v16, C = sd_v15

before:

<details>

<summary>old `-wc` procedure</summary>

![grid-0001](https://github.com/s1dlx/meh/assets/32277961/8d4baf42-58c2-4d8d-925a-1067cf4cbad9)

</details>

after:

<details>

<summary>new `-wc` procedure</summary>

![grid-0002](https://github.com/s1dlx/meh/assets/32277961/d8437342-650b-4cbc-a93f-67f05166b18e)

</details>